### PR TITLE
Rendering Context

### DIFF
--- a/Hana/src/Hana/Renderer/GraphicsContext.h
+++ b/Hana/src/Hana/Renderer/GraphicsContext.h
@@ -1,0 +1,11 @@
+#pragma once
+
+namespace Hana
+{
+	class GraphicsContext
+	{
+	public:
+		virtual void Init() = 0;
+		virtual void SwapBuffers() = 0;
+	};
+}

--- a/Hana/src/Platform/OpenGL/OpenGLContext.h
+++ b/Hana/src/Platform/OpenGL/OpenGLContext.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#include "Hana/Renderer/GraphicsContext.h"
+
+struct GLFWwindow;
+
+namespace Hana
+{
+	class OpenGLContext : public GraphicsContext
+	{
+	public:
+		OpenGLContext(GLFWwindow* windowHandle);
+
+		virtual void Init() override;
+		virtual void SwapBuffers() override;
+
+	private:
+		GLFWwindow* m_WindowHandle;
+	};
+}

--- a/Hana/src/Platform/OpenGL/OpenGLContextcpp.cpp
+++ b/Hana/src/Platform/OpenGL/OpenGLContextcpp.cpp
@@ -1,0 +1,27 @@
+#include "hnpch.h"
+#include "OpenGLContext.h"
+
+#include <GLFW/glfw3.h>
+#include <glad/glad.h>
+#include <gl/GL.h>
+
+namespace Hana
+{
+	OpenGLContext::OpenGLContext(GLFWwindow* window)
+		: m_WindowHandle(window)
+	{
+		HN_CORE_ASSERT(window, "Window handle is null!")
+	}
+
+	void OpenGLContext::Init()
+	{
+		glfwMakeContextCurrent(m_WindowHandle);
+		int status = gladLoadGLLoader((GLADloadproc)glfwGetProcAddress);
+		HN_CORE_ASSERT(status, "Failed to initialize Glad!");
+	}
+
+	void OpenGLContext::SwapBuffers()
+	{
+		glfwSwapBuffers(m_WindowHandle);
+	}
+}

--- a/Hana/src/Platform/Windows/WindowsWindow.cpp
+++ b/Hana/src/Platform/Windows/WindowsWindow.cpp
@@ -5,7 +5,7 @@
 #include "Hana/Events/KeyEvent.h"
 #include "Hana/Events/MouseEvent.h"
 
-#include <glad/glad.h>
+#include "Platform/OpenGL/OpenGLContext.h"
 
 namespace Hana
 {
@@ -49,9 +49,10 @@ namespace Hana
 		}
 
 		m_Window = glfwCreateWindow((int)props.Width, (int)props.Height, m_Data.Title.c_str(), nullptr, nullptr);
-		glfwMakeContextCurrent(m_Window);
-		int status = gladLoadGLLoader((GLADloadproc)glfwGetProcAddress);
-		HN_CORE_ASSERT(status, "Failed to initialize Glad!");
+
+		m_Context = new OpenGLContext(m_Window);
+		m_Context->Init();
+
 		glfwSetWindowUserPointer(m_Window, &m_Data);
 		SetVSync(true);
 
@@ -154,7 +155,7 @@ namespace Hana
 	void WindowsWindow::OnUpdate()
 	{
 		glfwPollEvents();
-		glfwSwapBuffers(m_Window);
+		m_Context->SwapBuffers();
 	}
 
 	void WindowsWindow::SetVSync(bool enabled)

--- a/Hana/src/Platform/Windows/WindowsWindow.h
+++ b/Hana/src/Platform/Windows/WindowsWindow.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "Hana/Window.h"
+#include "Hana/Renderer/GraphicsContext.h"
 
 #include <GLFW/glfw3.h>
 
@@ -29,6 +30,7 @@ namespace Hana
 		virtual void Shutdown();
 	private:
 		GLFWwindow* m_Window;
+		GraphicsContext* m_Context;
 
 		struct WindowData
 		{


### PR DESCRIPTION
- Created GraphicsContext virtual class
- Created OpenGLContext class inherits from GraphicsContext
- Move the logic that links glfw with opengl to opengl context class in Windowswindow

https://www.youtube.com/watch?v=YZKEjaCnsjU&list=PLlrATfBNZ98dC-V-N3m0Go4deliWHPFwT&index=27