### PR TITLE
Bug fix

### DIFF
--- a/Hana/src/Hana/LayerStack.cpp
+++ b/Hana/src/Hana/LayerStack.cpp
@@ -29,7 +29,7 @@ namespace Hana
 	void LayerStack::PopLayer(Layer* layer)
 	{
 		auto it = std::find(m_Layers.begin(), m_Layers.begin() + m_LayerInsertIndex, layer);
-		if (it != m_Layers.end())
+		if (it != m_Layers.begin() + m_LayerInsertIndex)
 		{
 			layer->OnDetach();
 			m_Layers.erase(it);

--- a/Hana/src/Platform/OpenGL/OpenGLVertexArray.cpp
+++ b/Hana/src/Platform/OpenGL/OpenGLVertexArray.cpp
@@ -53,18 +53,17 @@ namespace Hana
 		glBindVertexArray(m_RendererID);
 		vertexBuffer->Bind();
 
-		uint32_t index = 0;
 		const BufferLayout& layout = vertexBuffer->GetLayout();
 		for (const BufferElement& element : layout)
 		{
-			glEnableVertexAttribArray(index);
-			glVertexAttribPointer(index,
+			glEnableVertexAttribArray(m_VertexBufferIndex);
+			glVertexAttribPointer(m_VertexBufferIndex,
 				element.GetComponentCount(),
 				ShaderDataTypeToOpenGLBaseType(element.Type),
 				element.Normalized ? GL_TRUE : GL_FALSE,
 				layout.GetStride(),
-				(const void*)element.Offset);
-			index++;
+				(const void*)(intptr_t)element.Offset);
+			m_VertexBufferIndex++;
 		}
 
 		m_VertexBuffers.push_back(vertexBuffer);

--- a/Hana/src/Platform/OpenGL/OpenGLVertexArray.h
+++ b/Hana/src/Platform/OpenGL/OpenGLVertexArray.h
@@ -21,6 +21,7 @@ namespace Hana
 
 	private:
 		uint32_t m_RendererID;
+		uint32_t m_VertexBufferIndex = 0;
 		std::vector<Ref<VertexBuffer>> m_VertexBuffers;
 		Ref<IndexBuffer> m_IndexBuffer;
 	};


### PR DESCRIPTION
### Changes
- Fix the type cast warning in OpenGLVertexArray
- Fix an issue when popping layer, we are not comparing the std::find result to the actual one over the last element in partial finding
- Fix an issue if we add multiple vertex buffers, the vertexAttrib will overwrite previous slots' data