### PR TITLE
Maintainance

### DIFF
--- a/Hana/src/Hana/Events/Event.h
+++ b/Hana/src/Hana/Events/Event.h
@@ -53,20 +53,18 @@ namespace Hana
 
 	class EventDispatcher
 	{
-		template<typename T>
-		using EventFn = std::function<bool(T&)>;
 	public:
 		EventDispatcher(Event& event)
 			: m_Event(event)
 		{
 		}
 
-		template<typename T>
-		bool Dispatch(EventFn<T> func)
+		template<typename T, typename F>
+		bool Dispatch(const F& func)
 		{
 			if (m_Event.GetEventType() == T::GetStaticType())
 			{
-				m_Event.Handled = func(*(T*)&m_Event);
+				m_Event.Handled = func(static_cast<T&>(m_Event));
 				return true;
 			}
 			return false;

--- a/Hana/src/Hana/Input.h
+++ b/Hana/src/Hana/Input.h
@@ -7,12 +7,17 @@ namespace Hana
 	class HANA_API Input
 	{
 	public:
+		Input(const Input&) = delete;
+		Input& operator=(const Input&) = delete;
+
 		inline static bool IsKeyPressed(int keycode) { return s_Instance->IsKeyPressedImpl(keycode); }
 		inline static bool IsMouseButtonPressed(int button) { return s_Instance->IsMouseButtonPressedImpl(button); }
 		inline static std::pair<float, float> GetMousePosition() { return s_Instance->GetMousePositionImpl(); }
 		inline static float GetMouseX() { return s_Instance->GetMouseXImpl(); }
 		inline static float GetMouseY() { return s_Instance->GetMouseYImpl(); }
 	protected:
+		Input() = default;
+
 		virtual bool IsKeyPressedImpl(int keycode) = 0;
 		virtual bool IsMouseButtonPressedImpl(int button) = 0;
 		virtual std::pair<float, float> GetMousePositionImpl() = 0;

--- a/Hana/src/Platform/OpenGL/OpenGLBuffer.cpp
+++ b/Hana/src/Platform/OpenGL/OpenGLBuffer.cpp
@@ -39,8 +39,8 @@ namespace Hana
 		: m_Count(count)
 	{
 		glCreateBuffers(1, &m_RendererID);
-		glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, m_RendererID);
-		glBufferData(GL_ELEMENT_ARRAY_BUFFER, count * sizeof(uint32_t), indices, GL_STATIC_DRAW);
+		glBindBuffer(GL_ARRAY_BUFFER, m_RendererID);
+		glBufferData(GL_ARRAY_BUFFER, count * sizeof(uint32_t), indices, GL_STATIC_DRAW);
 	}
 
 	OpenGLIndexBuffer::~OpenGLIndexBuffer()

--- a/premake5.lua
+++ b/premake5.lua
@@ -9,6 +9,11 @@ workspace "Hana"
 		"Dist"
 	}
 
+	flags
+	{
+		"MultiProcessorCompile"
+	}
+
 outputdir = "%{cfg.buildcfg}-%{cfg.system}-%{cfg.architecture}"
 
 -- Include directories relative to root folder (solution directory)


### PR DESCRIPTION
### Changes
- Enable multiprocessor compilation in premake
- Use GL_ARRAY_BUFFER for the initial bind in index buffer constructor
    - GL_ARRAY_BUFFER is just a general buffer, it can hold any data. 
    - The representation of the data is not important at this stage
- Make Input a true singleton
- Avoid using std::function in event dispatcher for performance purpose