### PR TITLE
2D Renderer Transform and Texture

### DIFF
--- a/Hana/src/Hana/Core/Window.h
+++ b/Hana/src/Hana/Core/Window.h
@@ -14,8 +14,8 @@ namespace Hana
 		unsigned int Height;
 
 		WindowProps(const std::string& title = "Hana Engine",
-			unsigned int width = 1280,
-			unsigned int height = 720)
+			unsigned int width = 1920,
+			unsigned int height = 1080)
 			: Title(title), Width(width), Height(height)
 		{
 		}

--- a/Hana/src/Hana/Renderer/Buffer.h
+++ b/Hana/src/Hana/Renderer/Buffer.h
@@ -33,10 +33,10 @@ namespace Hana
 		std::string Name;
 		ShaderDataType Type = ShaderDataType::None;
 		uint32_t Size = 0;
-		uint32_t Offset = 0;
+		size_t Offset = 0;
 		bool Normalized = false;
 
-		BufferElement() {}
+		BufferElement() = default;
 
 		BufferElement(ShaderDataType type, const std::string& name, bool normalized = false)
 			: Name(name)
@@ -90,7 +90,7 @@ namespace Hana
 	private:
 		void CalculateOffsetsAndStride()
 		{
-			uint32_t offset = 0;
+			size_t offset = 0;
 			m_Stride = 0;
 			for (BufferElement& element : m_Elements)
 			{

--- a/Hana/src/Hana/Renderer/OrthographicCamera.cpp
+++ b/Hana/src/Hana/Renderer/OrthographicCamera.cpp
@@ -26,5 +26,4 @@ namespace Hana
 		m_ViewMatrix = glm::inverse(transform);
 		m_ViewProjectionMatrix = m_ProjectionMatrix * m_ViewMatrix;
 	}
-
 }

--- a/Hana/src/Hana/Renderer/Renderer2D.cpp
+++ b/Hana/src/Hana/Renderer/Renderer2D.cpp
@@ -13,6 +13,7 @@ namespace Hana
 	{
 		Ref<VertexArray> QuadVertexArray;
 		Ref<Shader> FlatColorShader;
+		Ref<Shader> TextureShader;
 	};
 
 	static Renderer2DStorage* s_Data;
@@ -25,10 +26,10 @@ namespace Hana
 
 		float squareVertices[5 * 4] =
 		{
-			-0.5f, -0.5f, 0.0f,
-			 0.5f, -0.5f, 0.0f,
-			 0.5f,  0.5f, 0.0f,
-			-0.5f,  0.5f, 0.0f
+			-0.5f, -0.5f, 0.0f, 0.0f, 0.0f,
+			 0.5f, -0.5f, 0.0f, 1.0f, 0.0f,
+			 0.5f,  0.5f, 0.0f, 1.0f, 1.0f,
+			-0.5f,  0.5f, 0.0f, 0.0f, 1.0f
 		};
 
 		Ref<VertexBuffer> squareVB;
@@ -36,6 +37,7 @@ namespace Hana
 		squareVB->SetLayout(
 			{
 				{ ShaderDataType::Float3, "a_Position" },
+				{ ShaderDataType::Float2, "a_TexCoord" },
 			});
 		s_Data->QuadVertexArray->AddVertexBuffer(squareVB);
 
@@ -45,6 +47,9 @@ namespace Hana
 		s_Data->QuadVertexArray->SetIndexBuffer(squareIB);
 
 		s_Data->FlatColorShader = Shader::Create("assets/shaders/FlatColor.glsl");
+		s_Data->TextureShader = Shader::Create("assets/shaders/Texture.glsl");
+		s_Data->TextureShader->Bind();
+		s_Data->TextureShader->SetInt("u_Texture", 0);
 	}
 
 	void Renderer2D::ShutDown()
@@ -56,6 +61,9 @@ namespace Hana
 	{
 		s_Data->FlatColorShader->Bind();
 		s_Data->FlatColorShader->SetMat4("u_ViewProjection", camera.GetViewProjectionMatrix());
+
+		s_Data->TextureShader->Bind();
+		s_Data->TextureShader->SetMat4("u_ViewProjection", camera.GetViewProjectionMatrix());
 	}
 
 	void Renderer2D::EndScene()
@@ -75,6 +83,25 @@ namespace Hana
 		glm::mat4 transform = glm::translate(glm::mat4(1.0f), position) * /* rotation */
 			glm::scale(glm::mat4(1.0f), { size.x, size.y, 1.0f });
 		s_Data->FlatColorShader->SetMat4("u_Transform", transform);
+
+		s_Data->QuadVertexArray->Bind();
+		RenderCommand::DrawIndexed(s_Data->QuadVertexArray);
+	}
+
+	void Renderer2D::DrawQuad(const glm::vec2& position, const glm::vec2& size, const Ref<Texture2D>& texture)
+	{
+		DrawQuad({ position.x, position.y, 0.0f }, size, texture);
+	}
+
+	void Renderer2D::DrawQuad(const glm::vec3& position, const glm::vec2& size, const Ref<Texture2D>& texture)
+	{
+		s_Data->TextureShader->Bind();
+
+		glm::mat4 transform = glm::translate(glm::mat4(1.0f), position) * /* rotation */
+			glm::scale(glm::mat4(1.0f), { size.x, size.y, 1.0f });
+		s_Data->TextureShader->SetMat4("u_Transform", transform);
+
+		texture->Bind();
 
 		s_Data->QuadVertexArray->Bind();
 		RenderCommand::DrawIndexed(s_Data->QuadVertexArray);

--- a/Hana/src/Hana/Renderer/Renderer2D.cpp
+++ b/Hana/src/Hana/Renderer/Renderer2D.cpp
@@ -5,7 +5,7 @@
 #include "Shader.h"
 #include "RenderCommand.h"
 
-#include "Platform/OpenGL/OpenGLShader.h"
+#include <glm/gtc/matrix_transform.hpp>
 
 namespace Hana
 {
@@ -54,9 +54,8 @@ namespace Hana
 
 	void Renderer2D::BeginScene(const OrthographicCamera& camera)
 	{
-		std::dynamic_pointer_cast<OpenGLShader>(s_Data->FlatColorShader)->Bind();
-		std::dynamic_pointer_cast<OpenGLShader>(s_Data->FlatColorShader)->UploadUniformMat4("u_ViewProjection", camera.GetViewProjectionMatrix());
-		std::dynamic_pointer_cast<OpenGLShader>(s_Data->FlatColorShader)->UploadUniformMat4("u_Transform", glm::mat4(1.0f));
+		s_Data->FlatColorShader->Bind();
+		s_Data->FlatColorShader->SetMat4("u_ViewProjection", camera.GetViewProjectionMatrix());
 	}
 
 	void Renderer2D::EndScene()
@@ -70,8 +69,12 @@ namespace Hana
 
 	void Renderer2D::DrawQuad(const glm::vec3& position, const glm::vec2& size, const glm::vec4& color)
 	{
-		std::dynamic_pointer_cast<OpenGLShader>(s_Data->FlatColorShader)->Bind();
-		std::dynamic_pointer_cast<OpenGLShader>(s_Data->FlatColorShader)->UploadUniformFloat4("u_Color", color);
+		s_Data->FlatColorShader->Bind();
+		s_Data->FlatColorShader->SetFloat4("u_Color", color);
+
+		glm::mat4 transform = glm::translate(glm::mat4(1.0f), position) * /* rotation */
+			glm::scale(glm::mat4(1.0f), { size.x, size.y, 1.0f });
+		s_Data->FlatColorShader->SetMat4("u_Transform", transform);
 
 		s_Data->QuadVertexArray->Bind();
 		RenderCommand::DrawIndexed(s_Data->QuadVertexArray);

--- a/Hana/src/Hana/Renderer/Renderer2D.h
+++ b/Hana/src/Hana/Renderer/Renderer2D.h
@@ -2,6 +2,8 @@
 
 #include "OrthographicCamera.h"
 
+#include "Texture.h"
+
 namespace Hana
 {
 	class Renderer2D
@@ -16,5 +18,7 @@ namespace Hana
 		// Primitives
 		static void DrawQuad(const glm::vec2& position, const glm::vec2& size, const glm::vec4& color);
 		static void DrawQuad(const glm::vec3& position, const glm::vec2& size, const glm::vec4& color);
+		static void DrawQuad(const glm::vec2& position, const glm::vec2& size, const Ref<Texture2D>& texture);
+		static void DrawQuad(const glm::vec3& position, const glm::vec2& size, const Ref<Texture2D>& texture);
 	};
 }

--- a/Hana/src/Hana/Renderer/Shader.h
+++ b/Hana/src/Hana/Renderer/Shader.h
@@ -3,6 +3,8 @@
 #include <string>
 #include <unordered_map>
 
+#include <glm/glm.hpp>
+
 namespace Hana
 {
 	class Shader
@@ -12,6 +14,10 @@ namespace Hana
 
 		virtual void Bind() const = 0;
 		virtual void Unbind() const = 0;
+
+		virtual void SetFloat3(const std::string& name, const glm::vec3& value) = 0;
+		virtual void SetFloat4(const std::string& name, const glm::vec4& value) = 0;
+		virtual void SetMat4(const std::string& name, const glm::mat4& value) = 0;
 
 		virtual const std::string& GetName() const = 0;
 

--- a/Hana/src/Hana/Renderer/Shader.h
+++ b/Hana/src/Hana/Renderer/Shader.h
@@ -15,6 +15,7 @@ namespace Hana
 		virtual void Bind() const = 0;
 		virtual void Unbind() const = 0;
 
+		virtual void SetInt(const std::string& name, int value) = 0;
 		virtual void SetFloat3(const std::string& name, const glm::vec3& value) = 0;
 		virtual void SetFloat4(const std::string& name, const glm::vec4& value) = 0;
 		virtual void SetMat4(const std::string& name, const glm::mat4& value) = 0;

--- a/Hana/src/Hana/Renderer/Texture.cpp
+++ b/Hana/src/Hana/Renderer/Texture.cpp
@@ -11,7 +11,7 @@ namespace Hana
 		switch (Renderer::GetAPI())
 		{
 			case RendererAPI::API::None:	HN_CORE_ASSERT(false, "RendererAPI::None is currently not supported!"); return nullptr;
-			case RendererAPI::API::OpenGL:	return std::make_shared<OpenGLTexture2D>(path);
+			case RendererAPI::API::OpenGL:	return CreateRef<OpenGLTexture2D>(path);
 		}
 
 		HN_CORE_ASSERT(false, "Unknown RendererAPI!");

--- a/Hana/src/Platform/OpenGL/OpenGLRendererAPI.cpp
+++ b/Hana/src/Platform/OpenGL/OpenGLRendererAPI.cpp
@@ -9,6 +9,8 @@ namespace Hana
 	{
 		glEnable(GL_BLEND);
 		glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
+
+		glEnable(GL_DEPTH_TEST);
 	}
 
 	void OpenGLRendererAPI::SetViewport(uint32_t x, uint32_t y, uint32_t width, uint32_t height)

--- a/Hana/src/Platform/OpenGL/OpenGLShader.cpp
+++ b/Hana/src/Platform/OpenGL/OpenGLShader.cpp
@@ -175,6 +175,21 @@ namespace Hana
 		glUseProgram(0);
 	}
 
+	void OpenGLShader::SetFloat3(const std::string& name, const glm::vec3& value)
+	{
+		UploadUniformFloat3(name, value);
+	}
+
+	void OpenGLShader::SetFloat4(const std::string& name, const glm::vec4& value)
+	{
+		UploadUniformFloat4(name, value);
+	}
+
+	void OpenGLShader::SetMat4(const std::string& name, const glm::mat4& value)
+	{
+		UploadUniformMat4(name, value);
+	}
+
 	void OpenGLShader::UploadUniformInt(const std::string& name, int value)
 	{
 		GLint location = glGetUniformLocation(m_RendererID, name.c_str());

--- a/Hana/src/Platform/OpenGL/OpenGLShader.cpp
+++ b/Hana/src/Platform/OpenGL/OpenGLShader.cpp
@@ -175,6 +175,11 @@ namespace Hana
 		glUseProgram(0);
 	}
 
+	void OpenGLShader::SetInt(const std::string& name, int value)
+	{
+		UploadUniformInt(name, value);
+	}
+
 	void OpenGLShader::SetFloat3(const std::string& name, const glm::vec3& value)
 	{
 		UploadUniformFloat3(name, value);

--- a/Hana/src/Platform/OpenGL/OpenGLShader.h
+++ b/Hana/src/Platform/OpenGL/OpenGLShader.h
@@ -18,6 +18,10 @@ namespace Hana
 		virtual void Bind() const override;
 		virtual void Unbind() const override;
 
+		virtual void SetFloat3(const std::string& name, const glm::vec3& value) override;
+		virtual void SetFloat4(const std::string& name, const glm::vec4& value) override;
+		virtual void SetMat4(const std::string& name, const glm::mat4& value) override;
+
 		virtual const std::string& GetName() const override { return m_Name; }
 
 		void UploadUniformInt(const std::string& name, int value);

--- a/Hana/src/Platform/OpenGL/OpenGLShader.h
+++ b/Hana/src/Platform/OpenGL/OpenGLShader.h
@@ -18,6 +18,7 @@ namespace Hana
 		virtual void Bind() const override;
 		virtual void Unbind() const override;
 
+		virtual void SetInt(const std::string& name, int value) override;
 		virtual void SetFloat3(const std::string& name, const glm::vec3& value) override;
 		virtual void SetFloat4(const std::string& name, const glm::vec4& value) override;
 		virtual void SetMat4(const std::string& name, const glm::mat4& value) override;

--- a/Hana/src/Platform/OpenGL/OpenGLTexture.cpp
+++ b/Hana/src/Platform/OpenGL/OpenGLTexture.cpp
@@ -37,6 +37,9 @@ namespace Hana
 		glTextureParameteri(m_RendererID, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
 		glTextureParameteri(m_RendererID, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
 
+		glTextureParameteri(m_RendererID, GL_TEXTURE_WRAP_S, GL_REPEAT);
+		glTextureParameteri(m_RendererID, GL_TEXTURE_WRAP_T, GL_REPEAT);
+
 		glTextureSubImage2D(m_RendererID, 0, 0, 0, m_Width, m_Height, dataFormat, GL_UNSIGNED_BYTE, data);
 
 		stbi_image_free(data);

--- a/Hana/src/Platform/OpenGL/OpenGLVertexArray.cpp
+++ b/Hana/src/Platform/OpenGL/OpenGLVertexArray.cpp
@@ -62,7 +62,7 @@ namespace Hana
 				ShaderDataTypeToOpenGLBaseType(element.Type),
 				element.Normalized ? GL_TRUE : GL_FALSE,
 				layout.GetStride(),
-				(const void*)(intptr_t)element.Offset);
+				(const void*)element.Offset);
 			m_VertexBufferIndex++;
 		}
 

--- a/Hana/src/Platform/Windows/WindowsWindow.cpp
+++ b/Hana/src/Platform/Windows/WindowsWindow.cpp
@@ -9,7 +9,7 @@
 
 namespace Hana
 {
-	static bool s_GLFWInitialized = false;
+	static uint8_t s_GLFWWindowCount = 0;
 
 	static void GLFWErrorCallback(int error, const char* description)
 	{
@@ -39,16 +39,16 @@ namespace Hana
 
 		HN_CORE_INFO("Creating window {0} ({1}, {2})", props.Title, props.Width, props.Height);
 
-		if (!s_GLFWInitialized)
+		if (s_GLFWWindowCount == 0)
 		{
-			// TODO: lfwTerminate on system shutdown
+			HN_CORE_INFO("Initializing GLFW");
 			int success = glfwInit();
 			HN_CORE_ASSERT(success, "Could not initialize GLFW!");
 			glfwSetErrorCallback(GLFWErrorCallback);
-			s_GLFWInitialized = true;
 		}
 
 		m_Window = glfwCreateWindow((int)props.Width, (int)props.Height, m_Data.Title.c_str(), nullptr, nullptr);
+		++s_GLFWWindowCount;
 
 		m_Context = CreateScope<OpenGLContext>(m_Window);
 		m_Context->Init();
@@ -150,6 +150,12 @@ namespace Hana
 	void WindowsWindow::Shutdown()
 	{
 		glfwDestroyWindow(m_Window);
+
+		if (--s_GLFWWindowCount == 0)
+		{
+			HN_CORE_INFO("Terminating GLFW");
+			glfwTerminate();
+		}
 	}
 
 	void WindowsWindow::OnUpdate()

--- a/Sandbox/assets/shaders/Texture.glsl
+++ b/Sandbox/assets/shaders/Texture.glsl
@@ -28,5 +28,5 @@ uniform sampler2D u_Texture;
 
 void main()
 {
-	color = texture(u_Texture, v_TexCoord);
+	color = texture(u_Texture, v_TexCoord * 10.0) * vec4(1.0, 0.8, 0.8, 1.0);
 }

--- a/Sandbox/imgui.ini
+++ b/Sandbox/imgui.ini
@@ -4,8 +4,8 @@ Size=400,400
 Collapsed=0
 
 [Window][Dear ImGui Demo]
-Pos=572,156
-Size=1210,1042
+Pos=68,464
+Size=468,299
 Collapsed=0
 
 [Window][Example: Log]
@@ -30,8 +30,7 @@ Size=93,48
 Collapsed=0
 
 [Window][Settings]
-ViewportPos=72,268
-ViewportId=0x1C33C293
+Pos=72,234
 Size=337,188
 Collapsed=0
 

--- a/Sandbox/src/Sandbox2D.cpp
+++ b/Sandbox/src/Sandbox2D.cpp
@@ -4,8 +4,6 @@
 #include <glm/gtc/matrix_transform.hpp>
 #include <glm/gtc/type_ptr.hpp>
 
-#include "Platform/OpenGL/OpenGLShader.h"
-
 Sandbox2D::Sandbox2D()
 	: Layer("Sandbox2D")
 	, m_CameraController(1920.f / 1080.f)
@@ -31,13 +29,9 @@ void Sandbox2D::OnUpdate(Hana::Timestep ts)
 	Hana::RenderCommand::Clear();
 
 	Hana::Renderer2D::BeginScene(m_CameraController.GetCamera());
-	Hana::Renderer2D::DrawQuad({ 0.0f, 0.0f }, { 1.0f, 1.0f }, { 0.8f, 0.2f, 0.3f, 1.0f });
+	Hana::Renderer2D::DrawQuad({ -1.0f, 0.0f }, { 0.8f, 0.8f }, { 0.8f, 0.2f, 0.3f, 1.0f });
+	Hana::Renderer2D::DrawQuad({ 0.5f, -0.5f }, { 0.5f, 0.75f }, { 0.2f, 0.3f, 0.8f, 1.0f });
 	Hana::Renderer2D::EndScene();
-
-	// TODO: Add these functions - Shader::SetMat4, Shader::SetFloat4
-	//std::dynamic_pointer_cast<Hana::OpenGLShader>(m_FlatColorShader)->Bind();
-	//std::dynamic_pointer_cast<Hana::OpenGLShader>(m_FlatColorShader)->UploadUniformFloat4("u_Color", m_SquareColor);
-
 }
 
 void Sandbox2D::OnImGuiRender()

--- a/Sandbox/src/Sandbox2D.cpp
+++ b/Sandbox/src/Sandbox2D.cpp
@@ -12,7 +12,7 @@ Sandbox2D::Sandbox2D()
 
 void Sandbox2D::OnAttach()
 {
-
+	m_CheckerboardTexture = Hana::Texture2D::Create("assets/textures/Checkerboard.png");
 }
 
 void Sandbox2D::OnDetach()
@@ -31,6 +31,7 @@ void Sandbox2D::OnUpdate(Hana::Timestep ts)
 	Hana::Renderer2D::BeginScene(m_CameraController.GetCamera());
 	Hana::Renderer2D::DrawQuad({ -1.0f, 0.0f }, { 0.8f, 0.8f }, { 0.8f, 0.2f, 0.3f, 1.0f });
 	Hana::Renderer2D::DrawQuad({ 0.5f, -0.5f }, { 0.5f, 0.75f }, { 0.2f, 0.3f, 0.8f, 1.0f });
+	Hana::Renderer2D::DrawQuad({ 0.0f, 0.0f, -0.1f }, { 10.0f, 10.0f }, m_CheckerboardTexture);
 	Hana::Renderer2D::EndScene();
 }
 

--- a/Sandbox/src/Sandbox2D.h
+++ b/Sandbox/src/Sandbox2D.h
@@ -21,6 +21,8 @@ private:
 	Hana::Ref<Hana::VertexArray> m_SquareVA;
 	Hana::Ref<Hana::Shader> m_FlatColorShader;
 
+	Hana::Ref<Hana::Texture2D> m_CheckerboardTexture;
+
 	glm::vec4 m_SquareColor = { 0.2f, 0.3f, 0.8f, 1.0f };
 
 };

--- a/scripts/Win-GenProjects.bat
+++ b/scripts/Win-GenProjects.bat
@@ -1,5 +1,5 @@
 @echo off
-pushd ..\
+pushd %~dp0\..\
 call vendor\bin\premake\premake5.exe vs2022
 popd
 PAUSE


### PR DESCRIPTION
## Description
Enable per quad base transform and texture. We can know adjust each quad's position, size and texture

## Changes
- Maintenance, change default window size to 1920 x 1080
- Maintenance, change buffer offset to size_t to avoid intptr_t casting
- Maintenance, modify GLFW window bool to count to enable multiple windows
- Maintenance, do glfwTerminate to release memory properly
- Create uniform upload abstraction function for Shader class
- Calculate and upload transform and texture to shader

## Test
- Load texture and have it tint red
  <img width="962" alt="image" src="https://github.com/GameDev-Shiki/Hana/assets/32504776/2ed2f111-e7cc-49f4-a849-0e51ce9adf45">

## Reference
- https://www.youtube.com/watch?v=-Qt12lcAF0Y&list=PLlrATfBNZ98dC-V-N3m0Go4deliWHPFwT&index=52&ab_channel=TheCherno
- https://www.youtube.com/watch?v=mW8eW3pLtmk&list=PLlrATfBNZ98dC-V-N3m0Go4deliWHPFwT&index=53&ab_channel=TheCherno