### PR TITLE
Single shader

### DIFF
--- a/Hana/src/Hana/Renderer/Renderer2D.cpp
+++ b/Hana/src/Hana/Renderer/Renderer2D.cpp
@@ -12,8 +12,8 @@ namespace Hana
 	struct Renderer2DStorage
 	{
 		Ref<VertexArray> QuadVertexArray;
-		Ref<Shader> FlatColorShader;
 		Ref<Shader> TextureShader;
+		Ref<Texture2D> WhiteTexture;
 	};
 
 	static Renderer2DStorage* s_Data;
@@ -46,7 +46,10 @@ namespace Hana
 		squareIB = IndexBuffer::Create(squareIndices, sizeof(squareIndices) / sizeof(uint32_t));
 		s_Data->QuadVertexArray->SetIndexBuffer(squareIB);
 
-		s_Data->FlatColorShader = Shader::Create("assets/shaders/FlatColor.glsl");
+		s_Data->WhiteTexture = Texture2D::Create(1, 1);
+		uint32_t whiteTextureData = 0xffffffff;
+		s_Data->WhiteTexture->SetData(&whiteTextureData, sizeof(uint32_t));
+
 		s_Data->TextureShader = Shader::Create("assets/shaders/Texture.glsl");
 		s_Data->TextureShader->Bind();
 		s_Data->TextureShader->SetInt("u_Texture", 0);
@@ -59,9 +62,6 @@ namespace Hana
 
 	void Renderer2D::BeginScene(const OrthographicCamera& camera)
 	{
-		s_Data->FlatColorShader->Bind();
-		s_Data->FlatColorShader->SetMat4("u_ViewProjection", camera.GetViewProjectionMatrix());
-
 		s_Data->TextureShader->Bind();
 		s_Data->TextureShader->SetMat4("u_ViewProjection", camera.GetViewProjectionMatrix());
 	}
@@ -77,12 +77,12 @@ namespace Hana
 
 	void Renderer2D::DrawQuad(const glm::vec3& position, const glm::vec2& size, const glm::vec4& color)
 	{
-		s_Data->FlatColorShader->Bind();
-		s_Data->FlatColorShader->SetFloat4("u_Color", color);
+		s_Data->TextureShader->SetFloat4("u_Color", color);
+		s_Data->WhiteTexture->Bind();
 
 		glm::mat4 transform = glm::translate(glm::mat4(1.0f), position) * /* rotation */
 			glm::scale(glm::mat4(1.0f), { size.x, size.y, 1.0f });
-		s_Data->FlatColorShader->SetMat4("u_Transform", transform);
+		s_Data->TextureShader->SetMat4("u_Transform", transform);
 
 		s_Data->QuadVertexArray->Bind();
 		RenderCommand::DrawIndexed(s_Data->QuadVertexArray);
@@ -95,13 +95,12 @@ namespace Hana
 
 	void Renderer2D::DrawQuad(const glm::vec3& position, const glm::vec2& size, const Ref<Texture2D>& texture)
 	{
-		s_Data->TextureShader->Bind();
+		s_Data->TextureShader->SetFloat4("u_Color", glm::vec4(1.0f));
+		texture->Bind();
 
 		glm::mat4 transform = glm::translate(glm::mat4(1.0f), position) * /* rotation */
 			glm::scale(glm::mat4(1.0f), { size.x, size.y, 1.0f });
 		s_Data->TextureShader->SetMat4("u_Transform", transform);
-
-		texture->Bind();
 
 		s_Data->QuadVertexArray->Bind();
 		RenderCommand::DrawIndexed(s_Data->QuadVertexArray);

--- a/Hana/src/Hana/Renderer/Texture.cpp
+++ b/Hana/src/Hana/Renderer/Texture.cpp
@@ -6,6 +6,18 @@
 
 namespace Hana
 {
+	Ref<Texture2D> Texture2D::Create(uint32_t width, uint32_t height)
+	{
+		switch (Renderer::GetAPI())
+		{
+			case RendererAPI::API::None:	HN_CORE_ASSERT(false, "RendererAPI::None is currently not supported!"); return nullptr;
+			case RendererAPI::API::OpenGL:	return CreateRef<OpenGLTexture2D>(width, height);
+		}
+
+		HN_CORE_ASSERT(false, "Unknown RendererAPI!");
+		return nullptr;
+	}
+
 	Ref<Texture2D> Texture2D::Create(const std::string& path)
 	{
 		switch (Renderer::GetAPI())

--- a/Hana/src/Hana/Renderer/Texture.h
+++ b/Hana/src/Hana/Renderer/Texture.h
@@ -13,12 +13,15 @@ namespace Hana
 		virtual uint32_t GetWidth() const = 0;
 		virtual uint32_t GetHeight() const = 0;
 
+		virtual void SetData(void* data, uint32_t size) = 0;
+
 		virtual void Bind(uint32_t slot = 0) const = 0;
 	};
 
 	class Texture2D : public Texture
 	{
 	public:
+		static Ref<Texture2D> Create(uint32_t width, uint32_t height);
 		static Ref<Texture2D> Create(const std::string& path);
 	};
 }

--- a/Hana/src/Platform/OpenGL/OpenGLRendererAPI.cpp
+++ b/Hana/src/Platform/OpenGL/OpenGLRendererAPI.cpp
@@ -31,5 +31,6 @@ namespace Hana
 	void OpenGLRendererAPI::DrawIndexed(const Ref<VertexArray>& vertexArray)
 	{
 		glDrawElements(GL_TRIANGLES, vertexArray->GetIndexBuffer()->GetCount(), GL_UNSIGNED_INT, nullptr);
+		glBindTexture(GL_TEXTURE_2D, 0);
 	}
 }

--- a/Hana/src/Platform/OpenGL/OpenGLTexture.cpp
+++ b/Hana/src/Platform/OpenGL/OpenGLTexture.cpp
@@ -3,10 +3,24 @@
 
 #include "stb_image.h"
 
-#include <glad/glad.h>
-
 namespace Hana
 {
+	OpenGLTexture2D::OpenGLTexture2D(uint32_t width, uint32_t height)
+		: m_Width(width), m_Height(height)
+	{
+		m_InternalFormat = GL_RGBA8;
+		m_DataFormat = GL_RGBA;
+
+		glCreateTextures(GL_TEXTURE_2D, 1, &m_RendererID);
+		glTextureStorage2D(m_RendererID, 1, m_InternalFormat, m_Width, m_Height);
+
+		glTextureParameteri(m_RendererID, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
+		glTextureParameteri(m_RendererID, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
+
+		glTextureParameteri(m_RendererID, GL_TEXTURE_WRAP_S, GL_REPEAT);
+		glTextureParameteri(m_RendererID, GL_TEXTURE_WRAP_T, GL_REPEAT);
+	}
+
 	OpenGLTexture2D::OpenGLTexture2D(const std::string& path)
 		: m_Path(path)
 	{
@@ -29,6 +43,9 @@ namespace Hana
 			dataFormat = GL_RGB;
 		}
 
+		m_InternalFormat = internalFormat;
+		m_DataFormat = dataFormat;
+
 		HN_CORE_ASSERT(internalFormat & dataFormat, "Format not supported!");
 
 		glCreateTextures(GL_TEXTURE_2D, 1, &m_RendererID);
@@ -48,6 +65,13 @@ namespace Hana
 	OpenGLTexture2D::~OpenGLTexture2D()
 	{
 		glDeleteTextures(1, &m_RendererID);
+	}
+
+	void OpenGLTexture2D::SetData(void* data, uint32_t size)
+	{
+		uint32_t bpp = m_DataFormat == GL_RGBA ? 4 : 3; 
+		HN_CORE_ASSERT(size == m_Width * m_Height * bpp, "Data must be entire exture!");
+		glTextureSubImage2D(m_RendererID, 0, 0, 0, m_Width, m_Height, m_DataFormat, GL_UNSIGNED_BYTE, data);
 	}
 
 	void OpenGLTexture2D::Bind(uint32_t slot) const

--- a/Hana/src/Platform/OpenGL/OpenGLTexture.h
+++ b/Hana/src/Platform/OpenGL/OpenGLTexture.h
@@ -2,16 +2,21 @@
 
 #include "Hana/Renderer/Texture.h"
 
+#include <glad/glad.h>
+
 namespace Hana
 {
 	class OpenGLTexture2D : public Texture2D
 	{
 	public:
+		OpenGLTexture2D(uint32_t width, uint32_t height);
 		OpenGLTexture2D(const std::string& path);
 		virtual ~OpenGLTexture2D();
 
 		virtual uint32_t GetWidth() const override { return m_Width; }
 		virtual uint32_t GetHeight() const override { return m_Height; }
+
+		virtual void SetData(void* data, uint32_t size) override;
 
 		virtual void Bind(uint32_t slot = 0) const override;
 
@@ -20,5 +25,6 @@ namespace Hana
 		uint32_t m_Width = 0;
 		uint32_t m_Height = 0;
 		uint32_t m_RendererID = 0;
+		GLenum m_InternalFormat, m_DataFormat;
 	};
 }

--- a/Hana/src/Platform/OpenGL/OpenGLVertexArray.cpp
+++ b/Hana/src/Platform/OpenGL/OpenGLVertexArray.cpp
@@ -62,7 +62,7 @@ namespace Hana
 				ShaderDataTypeToOpenGLBaseType(element.Type),
 				element.Normalized ? GL_TRUE : GL_FALSE,
 				layout.GetStride(),
-				(const void*)element.Offset);
+				(const void*)(intptr_t)element.Offset);
 			m_VertexBufferIndex++;
 		}
 

--- a/Sandbox/assets/shaders/Texture.glsl
+++ b/Sandbox/assets/shaders/Texture.glsl
@@ -24,9 +24,10 @@ layout(location = 0) out vec4 color;
 
 in vec2 v_TexCoord;
 
+uniform vec4 u_Color;
 uniform sampler2D u_Texture;
 
 void main()
 {
-	color = texture(u_Texture, v_TexCoord * 10.0) * vec4(1.0, 0.8, 0.8, 1.0);
+	color = texture(u_Texture, v_TexCoord * 10.0) * u_Color;
 }

--- a/Sandbox/imgui.ini
+++ b/Sandbox/imgui.ini
@@ -4,7 +4,8 @@ Size=400,400
 Collapsed=0
 
 [Window][Dear ImGui Demo]
-Pos=68,464
+ViewportPos=391,1208
+ViewportId=0xE927CF2F
 Size=468,299
 Collapsed=0
 
@@ -30,7 +31,7 @@ Size=93,48
 Collapsed=0
 
 [Window][Settings]
-Pos=72,234
+Pos=26,17
 Size=337,188
 Collapsed=0
 


### PR DESCRIPTION
## Description
We have two shaders, and when we draw quads, we keep switching shaders and this is neither necessary nor performance friendly. We can combine them into one shader, and create a pure white texture through code when we want color.

## Changes
- Created a new Texture constructor and setter to allow code generated texture
- Reset texture binding slot each DrawIndex

## Test
<img width="963" alt="image" src="https://github.com/GameDev-Shiki/Hana/assets/32504776/c08297df-f5bd-4777-9d2c-d5aee437abe8">


## Reference
https://www.youtube.com/watch?v=-myXuS3t1W4&list=PLlrATfBNZ98dC-V-N3m0Go4deliWHPFwT&index=54&ab_channel=TheCherno